### PR TITLE
unserialize() on an array

### DIFF
--- a/net/xenapi/XenAPI/api.php
+++ b/net/xenapi/XenAPI/api.php
@@ -4063,7 +4063,7 @@ class XenAPI {
 
         if (!empty($diff_array['custom_fields'])) {
             // Check the difference in the custom fields.
-            $custom_fields_diff_array = array_diff_assoc(unserialize($user->data['custom_fields']), unserialize($diff_array['custom_fields']));
+            $custom_fields_diff_array = array_diff_assoc($user->data['custom_fields'], unserialize($diff_array['custom_fields']));
 
             unset($diff_array['custom_fields']);
 


### PR DESCRIPTION
$user->data['custom_fields'] is always an array, consequently an unserialization produces a warning.