### PR TITLE
added getGroups action, getUsers fix

### DIFF
--- a/net/xenapi/XenAPI/api.php
+++ b/net/xenapi/XenAPI/api.php
@@ -2642,7 +2642,7 @@ class RestAPI {
                 *   - api.php?action=getUsers&value=C*
                 */
 
-                if ($this->hasRequest('value') && strpos($this->getRequest('value', ',')) !== false) {
+                if ($this->hasRequest('value') && strpos($this->getRequest('value'), ',') !== false) {
                     $userIds = explode(',', $this->getRequest('value'));
                     $results = [];
                     foreach ($userIds as $userId) {

--- a/net/xenapi/XenAPI/api.php
+++ b/net/xenapi/XenAPI/api.php
@@ -106,7 +106,8 @@ class RestAPI {
         'getavatar'                => 'public',
         'getconversation'          => 'private',
         'getconversations'         => 'private',
-        'getgroup'                 => 'public', 
+        'getgroup'                 => 'public',
+        'getgroups'                => 'public',
         'getnode'                  => 'public',
         'getnodes'                 => 'public',
         'getpost'                  => 'public',
@@ -1925,6 +1926,16 @@ class RestAPI {
                 } else {
                     // Group was found, send response.
                     $this->sendResponse($group);
+                }
+            case 'getgroups':
+                // Get the groups from XenForo.
+                $groups = $this->getXenAPI()->getGroups();
+                if (!$groups) {
+                    // Could not find any group, throw error.
+                    $this->throwError(4, 'group', $string);
+                } else {
+                    // Groups were found, send response.
+                    $this->sendResponse($groups);
                 }
             case 'getconversations':
                 /**
@@ -4095,6 +4106,11 @@ class XenAPI {
         // Get the group from the database.
         return $this->getDatabase()->fetchRow("SELECT * FROM `xf_user_group` WHERE `user_group_id` = " . $this->getDatabase()->quote($group) 
             . " OR `title` = " . $this->getDatabase()->quote($group) . " OR `user_title` = " . $this->getDatabase()->quote($group));
+    }
+
+    public function getGroups() {
+        // Get the groups list from the database. 
+        return $this->getDatabase()->fetchAll("SELECT * FROM `xf_user_group`");
     }
 
     /**


### PR DESCRIPTION
The add-on on the community has been marked as "Unmaintained".
[https://xenforo.com/community/resources/xenapi-xenforo-php-rest-api.902/](url)
Tried to contact @Contex by email, after no reply I've decided to implement by myself the getGroups action.

Request:
api.php?action=getGroups

Examples:
api.php?action=getGroups

Response:
`[{
  "user_group_id": 1,
  "title": "Unregistered / Unconfirmed",
  "display_style_priority": 0,
  "username_css": "",
  "user_title": "Guest",
  "banner_css_class": "",
  "banner_text": ""
},
{
  "user_group_id": 2,
  "title": "Registered",
  "display_style_priority": 0,
  "username_css": "",
  "user_title": "",
  "banner_css_class": "",
  "banner_text": ""
},
{
  "user_group_id": 3,
  "title": "Administrative",
  "display_style_priority": 1000,
  "username_css": "",
  "user_title": "Administrator",
  "banner_css_class": "",
  "banner_text": ""
},
{
  "user_group_id": 4,
  "title": "Moderating",
  "display_style_priority": 900,
  "username_css": "",
  "user_title": "Moderator",
  "banner_css_class": "userBanner bannerHidden",
  "banner_text": ""
}]`
